### PR TITLE
Use escape of Qutation Mark for use with ngerman babel package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ clap = { version = "4.3.22", features = ["derive"] }
 exitcode = "1.1.2"
 regex = "1.9.3"
 scraper = "0.17.1"
+
+[features]
+babel_ngerman = []

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -11,32 +11,32 @@ impl HighlightedText {
         // formatted separately otherwise it will cause issues in pdf after rendering
         for text_piece in self.text.split('\n') {
             let color_name = &self.hex_color;
-            let mut out = format!(
-                "\\texttt{{{}}}",
-                // the first 5 replacements are because we parse html (we need to un-escape)
-                // the rest is necessary because LaTeX wouldn't compile otherwise
-                text_piece
-                    // .replace("\"", "\\\"")
-                    .replace("&lt;", "<")
-                    .replace("&gt;", ">")
-                    .replace("&quot;", "\"")
-                    .replace("&#39;", "'")
-                    .replace("&amp;", "&")
-                    .replace('\\', "\\textbackslash") // don't add the braces here yet
-                    .replace('}', "\\}") // escape the braces
-                    .replace('{', "\\{")
-                    .replace("\\textbackslash", "\\textbackslash{}") // now add the empty braces to break the command without escaping them
-                    .replace(' ', "\\ ")
-                    .replace('\t', "\\ ".repeat(conf.tab_size).as_str())
-                    .replace('_', "\\_")
-                    .replace('^', " \\^") // the space in front is necessary otherwise it would add hat to letters
-                    .replace('&', "\\&")
-                    .replace('%', "\\%")
-                    .replace('#', "\\#")
-                    .replace('~', "\\~")
-                    .replace('$', "\\$")
-                    .replace('"', "\\dq{}")
-            );
+            // the first 5 replacements are because we parse html (we need to un-escape)
+            // the rest is necessary because LaTeX wouldn't compile otherwise
+            let text_piece = text_piece
+                // .replace("\"", "\\\"")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&quot;", "\"")
+                .replace("&#39;", "'")
+                .replace("&amp;", "&")
+                .replace('\\', "\\textbackslash") // don't add the braces here yet
+                .replace('}', "\\}") // escape the braces
+                .replace('{', "\\{")
+                .replace("\\textbackslash", "\\textbackslash{}") // now add the empty braces to break the command without escaping them
+                .replace(' ', "\\ ")
+                .replace('\t', "\\ ".repeat(conf.tab_size).as_str())
+                .replace('_', "\\_")
+                .replace('^', " \\^") // the space in front is necessary otherwise it would add hat to letters
+                .replace('&', "\\&")
+                .replace('%', "\\%")
+                .replace('#', "\\#")
+                .replace('~', "\\~")
+                .replace('$', "\\$");
+            #[cfg(feature = "babel_ngerman")]
+            let text_piece = text_piece.replace('"', "\\dq{}");
+
+            let mut out = format!("\\texttt{{{}}}", text_piece);
             // if there is some other additional highlight, wrap the text in it
             if self.bold {
                 out = format!("\\textbf{{{}}}", out);
@@ -54,7 +54,7 @@ impl HighlightedText {
             out = format!("{}{}{}", conf.escape_start, out, conf.escape_end);
             mini_buffer.push(out);
         }
-        return mini_buffer.join("\n");
+        mini_buffer.join("\n")
     }
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -35,6 +35,7 @@ impl HighlightedText {
                     .replace('#', "\\#")
                     .replace('~', "\\~")
                     .replace('$', "\\$")
+                    .replace('"', "\\dq{}")
             );
             // if there is some other additional highlight, wrap the text in it
             if self.bold {


### PR DESCRIPTION
If you use a vowel after a `"` while using the ngerman babel package, the vowel will not be escaped correctly:

![image](https://github.com/TomLebeda/chroma_code/assets/34603476/3f81b02c-2b45-4cfe-81e0-9ff5e270fd7b)

If the `"` is replaced by a `\dq{}` it works again, but only if the ngerman babel package is active. Probably would be best to provide an additional configuration parameter, but for now I only added it as an extra feature :shrug:.

![image](https://github.com/TomLebeda/chroma_code/assets/34603476/a02a5436-650f-4632-bc00-8eb8fa8d8b75)

Latex Sample
```latex
\documentclass{article}

\usepackage{xcolor}
\usepackage{listings}
\usepackage[ngerman]{babel}

\begin{document}

\input{test.rs.tex}

\end{document}
```