### PR TITLE
Fix: `--` outputs a ligature, so use `-{}-`

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -39,6 +39,7 @@ impl HighlightedText {
                     .replace('#', "\\#")
                     .replace('~', "\\~")
                     .replace('$', "\\$")
+                    .replace("--", "-{}-") // replace LaTeX `--` ligature with two dashes
                     .replace('"', if conf.german { "\\dq{}" } else { "\"" })
             );
 


### PR DESCRIPTION
LaTeX considers `--` as a single LaTeX-ligature. Using `-{}-` would fix that.